### PR TITLE
[CI] replace deprecated ::set-env command with $GITHUB_ENV

### DIFF
--- a/.github/workflows/toolchain-turris-cok-sdk.yml
+++ b/.github/workflows/toolchain-turris-cok-sdk.yml
@@ -38,7 +38,7 @@ jobs:
           docker cp $id:/turris-build/version.txt turris-os-version.txt
           docker rm -v $id
           export tag_detail=$(cat turris-os-version.txt)
-          echo "::set-env name=tag_detail::$tag_detail" 
+          echo "tag_detail=$tag_detail" >> $GITHUB_ENV
           docker tag selwtf/turris-cok-sdk:${{ matrix.device }}-${{ matrix.tag }} selwtf/turris-cok-sdk:$tag_detail
         continue-on-error: true
 

--- a/.github/workflows/toolchain-turris-sdk.yml
+++ b/.github/workflows/toolchain-turris-sdk.yml
@@ -36,7 +36,7 @@ jobs:
           docker cp $id:/turris-build/version.txt turris-os-version.txt
           docker rm -v $id
           export tag_detail=$(cat turris-os-version.txt)
-          echo "::set-env name=tag_detail::$tag_detail" 
+          echo "tag_detail=$tag_detail" >> $GITHUB_ENV
           docker tag selwtf/turris-sdk:${{ matrix.device }}-${{ matrix.tag }} selwtf/turris-sdk:$tag_detail
         continue-on-error: true
 


### PR DESCRIPTION
See: https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/